### PR TITLE
Fix issue with empty DockerHub Response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
     mavenCentral()
 }
 
-version = '1.4.3'
+version = '1.4.4'
 
 sourceSets {
 

--- a/src/main/java/io/linuxserver/fleet/core/FleetBeans.java
+++ b/src/main/java/io/linuxserver/fleet/core/FleetBeans.java
@@ -72,6 +72,7 @@ public class FleetBeans {
         dockerHubDelegate       = new DockerHubDelegate(new DockerHubV2Client(properties.getDockerHubCredentials()));
         taskManager             = new TaskManager();
         synchronisationDelegate = new SynchronisationDelegate(imageDelegate, repositoryDelegate, dockerHubDelegate);
+        synchronisationDelegate.setFullRmProtected(properties.isFullRmProtected());
         userDelegate            = new UserDelegate(passwordEncoder, new DefaultUserDAO(databaseConnection));
         taskDelegate            = new TaskDelegate(this);
         authenticationDelegate  = new DefaultAuthenticationDelegate(AuthenticatorFactory.getAuthenticator(this));

--- a/src/main/java/io/linuxserver/fleet/core/FleetProperties.java
+++ b/src/main/java/io/linuxserver/fleet/core/FleetProperties.java
@@ -71,6 +71,16 @@ public class FleetProperties {
         return Integer.parseInt(getStringProperty("fleet.refresh.interval"));
     }
 
+    public boolean isFullRmProtected() {
+
+        final String safe = getStringProperty("fleet.sync.fullrm.protected");
+        if (null == safe) {
+            return true;
+        }
+
+        return "true".equalsIgnoreCase(safe);
+    }
+
     public DockerHubCredentials getDockerHubCredentials() {
 
         String username = getStringProperty("fleet.dockerhub.username");

--- a/src/main/java/io/linuxserver/fleet/delegate/SynchronisationDelegate.java
+++ b/src/main/java/io/linuxserver/fleet/delegate/SynchronisationDelegate.java
@@ -40,6 +40,8 @@ public class SynchronisationDelegate implements SynchronisationContext {
 
     private List<SynchronisationListener> listeners;
 
+    private boolean fullRmProtected;
+
     public SynchronisationDelegate(ImageDelegate imageDelegate, RepositoryDelegate repositoryDelegate, DockerHubDelegate dockerHubDelegate) {
 
         this.imageDelegate = imageDelegate;
@@ -48,6 +50,10 @@ public class SynchronisationDelegate implements SynchronisationContext {
 
         this.listeners = new ArrayList<>();
         registerListener(new DefaultLoggingSyncListener());
+    }
+
+    public final void setFullRmProtected(final boolean fullRmProtected) {
+        this.fullRmProtected = fullRmProtected;
     }
 
     /**
@@ -85,5 +91,10 @@ public class SynchronisationDelegate implements SynchronisationContext {
     @Override
     public DockerHubDelegate getDockerHubDelegate() {
         return dockerHubDelegate;
+    }
+
+    @Override
+    public boolean isFullRmProtected() {
+        return fullRmProtected;
     }
 }

--- a/src/main/java/io/linuxserver/fleet/sync/SynchronisationContext.java
+++ b/src/main/java/io/linuxserver/fleet/sync/SynchronisationContext.java
@@ -36,4 +36,6 @@ public interface SynchronisationContext {
     RepositoryDelegate getRepositoryDelegate();
 
     DockerHubDelegate getDockerHubDelegate();
+
+    boolean isFullRmProtected();
 }


### PR DESCRIPTION
An empty response from DockerHub was triggering the delete function per repository/image. This needs to be protected against (but disabled if needed).